### PR TITLE
Update ExoPlayer version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,10 +31,14 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+
+    compileOptions {
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.0.2'
-    implementation 'com.google.android.exoplayer:exoplayer:2.10.3'
-    implementation 'androidx.core:core:1.0.2'
-    implementation 'androidx.media:media:1.0.1'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'com.google.android.exoplayer:exoplayer:2.11.1'
+    implementation 'androidx.core:core:1.1.0'
+    implementation 'androidx.media:media:1.1.0'
 }

--- a/android/src/main/java/danielr2001/audioplayer/audioplayers/BackgroundAudioPlayer.java
+++ b/android/src/main/java/danielr2001/audioplayer/audioplayers/BackgroundAudioPlayer.java
@@ -13,10 +13,12 @@ import android.content.Context;
 import android.net.Uri;
 import android.os.Binder;
 import android.os.IBinder;
+import android.util.Log;
 
 import androidx.annotation.Nullable;
 
 import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.ExoPlayerFactory;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.SimpleExoPlayer;
@@ -63,6 +65,8 @@ public class BackgroundAudioPlayer implements AudioPlayer {
     private ArrayList<AudioObject> audioObjects;
     private AudioObject audioObject;
 
+    private static final String TAG = "BackgroundAudioPlayer";
+
     @Override
     public void setAudioObjects(ArrayList<AudioObject> audioObjects) {
     }
@@ -87,7 +91,7 @@ public class BackgroundAudioPlayer implements AudioPlayer {
 
     @Override
     public void initExoPlayer(int index) {
-        player = ExoPlayerFactory.newSimpleInstance(this.context, new DefaultTrackSelector());
+        player = new SimpleExoPlayer.Builder(context).setTrackSelector(new DefaultTrackSelector(context)).build();
         DefaultDataSourceFactory dataSourceFactory = new DefaultDataSourceFactory(this.context,
                 Util.getUserAgent(this.context, "exoPlayerLibrary"));
         // playlist/single audio load
@@ -391,6 +395,11 @@ public class BackgroundAudioPlayer implements AudioPlayer {
                 }
                 // handle of released is in release method!
                 }
+            }
+
+            @Override
+            public void onPlayerError(ExoPlaybackException error) {
+                Log.e(TAG, error.getMessage());
             }
         });
     }

--- a/android/src/main/java/danielr2001/audioplayer/audioplayers/ForegroundAudioPlayer.java
+++ b/android/src/main/java/danielr2001/audioplayer/audioplayers/ForegroundAudioPlayer.java
@@ -18,11 +18,13 @@ import android.os.Binder;
 import android.os.IBinder;
 
 import android.support.v4.media.session.MediaSessionCompat;
+import android.util.Log;
 
 import androidx.annotation.Nullable;
 import androidx.media.session.MediaButtonReceiver;
 
 import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.ExoPlayerFactory;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.SimpleExoPlayer;
@@ -77,6 +79,8 @@ public class ForegroundAudioPlayer extends Service implements AudioPlayer {
 
     private ArrayList<AudioObject> audioObjects;
     private AudioObject audioObject;
+
+    private static final String TAG = "ForegroundAudioPlayer";
 
     @Nullable
     @Override
@@ -194,7 +198,7 @@ public class ForegroundAudioPlayer extends Service implements AudioPlayer {
 
     @Override
     public void initExoPlayer(int index) {
-        player = ExoPlayerFactory.newSimpleInstance(this.context, new DefaultTrackSelector());
+        player = new SimpleExoPlayer.Builder(context).setTrackSelector(new DefaultTrackSelector(context)).build();
         DefaultDataSourceFactory dataSourceFactory = new DefaultDataSourceFactory(this.context,
                 Util.getUserAgent(this.context, "exoPlayerLibrary"));
         player.setForegroundMode(true);
@@ -532,6 +536,11 @@ public class ForegroundAudioPlayer extends Service implements AudioPlayer {
                     break;
                 } // handle of released is in release method!
                 }
+            }
+
+            @Override
+            public void onPlayerError(ExoPlaybackException error) {
+                Log.e(TAG, error.getMessage());
             }
         });
     }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -43,7 +43,7 @@ flutter {
 }
 
 dependencies {
-    androidTestImplementation 'androidx.annotation:annotation:1.0.1'
-    androidTestImplementation 'androidx.test:runner:1.1.1'
-    androidTestImplementation 'androidx.test:rules:1.1.1'
+    androidTestImplementation 'androidx.annotation:annotation:1.1.0'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test:rules:1.2.0'
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:3.5.3'
     }
 }
 

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,2 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
-
+android.useAndroidX=true
+android.enableJetifier=true
+android.enableR8=true

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jun 23 08:50:38 CEST 2017
+#Sat Jan 04 11:04:28 IST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,9 +6,9 @@ import 'package:path_provider/path_provider.dart';
 import 'player_widget.dart';
 import 'package:http/http.dart';
 
-const kUrl1 = 'https://www.bensound.org/bensound-music/bensound-buddy.mp3';
-const kUrl2 = 'https://www.bensound.org/bensound-music/bensound-epic.mp3';
-const kUrl3 = 'https://www.bensound.org/bensound-music/bensound-onceagain.mp3';
+const kUrl1 = 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3';
+const kUrl2 = 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-2.mp3';
+const kUrl3 = 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-3.mp3';
 
 //const kUrl3 = 'http://bbcmedia.ic.llnwd.net/stream/bbcmedia_radio1xtra_mf_p';
 final List<String> urls = [kUrl1, kUrl2, kUrl3];


### PR DESCRIPTION
- Updated ExoPlayer version 
- Fixed broken music file of example

- Why will need to update the ExoPlayer version? 
     - Sometime online streaming stop or can't able to play long audio file. To prevent this issue we will need to use the wake lock. Updated version of ExoPlayer take care of acquire/release the wake lock.  
    - [Release Note](https://github.com/google/ExoPlayer/blob/release-v2/RELEASENOTES.md#2110-2019-12-11 ) 
    - [More detail of issue](https://github.com/google/ExoPlayer/issues/5846) 