### PR TITLE
Fixed NullPointerException causing crash

### DIFF
--- a/android/src/main/java/danielr2001/audioplayer/AudioPlayerPlugin.java
+++ b/android/src/main/java/danielr2001/audioplayer/AudioPlayerPlugin.java
@@ -90,7 +90,7 @@ public class AudioPlayerPlugin implements MethodCallHandler {
   private AudioPlayerPlugin(final MethodChannel channel, Activity activity) {
     this.channel = channel;
     this.activity = activity;
-    this.context = activity.getApplicationContext();
+    this.context = activity;
     this.channel.setMethodCallHandler(this);
   }
 


### PR DESCRIPTION
```
java.lang.NullPointerException: Attempt to invoke virtual method 'android.content.Context android.app.Activity.getApplicationContext()' on a null object reference
	at danielr2001.audioplayer.AudioPlayerPlugin.<init>(AudioPlayerPlugin.java:93)
	at danielr2001.audioplayer.AudioPlayerPlugin.registerWith(AudioPlayerPlugin.java:87)
	at io.flutter.plugins.GeneratedPluginRegistrant.registerWith(GeneratedPluginRegistrant.java:33)
	at xyz.a5in.a5yin.MusicApplication.registerWith(MusicApplication.java:26)
	at vn.hunghd.flutterdownloader.DownloadWorker.startBackgroundIsolate(DownloadWorker.java:124)
	at vn.hunghd.flutterdownloader.DownloadWorker.access$000(DownloadWorker.java:59)
	at vn.hunghd.flutterdownloader.DownloadWorker$1.run(DownloadWorker.java:97)
	at android.os.Handler.handleCallback(Handler.java:883)
	at android.os.Handler.dispatchMessage(Handler.java:100)
	at android.os.Looper.loop(Looper.java:227)
	at android.app.ActivityThread.main(ActivityThread.java:7523)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:539)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:953)
```